### PR TITLE
(feat) require old password to change password

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ app.post('/api/inbound', email.receive, email.verify);
 app.get('/api/escrow/', user.checkSession, email.fetchEscrows);
 app.post('/api/user/settings/card', user.checkSession, user.addCard, user.update);
 app.put('/api/user/settings/rate', user.checkSession, user.changeRate, user.update);
-app.put('/api/user/settings/password', user.checkSession, user.changePassword, user.update);
+app.put('/api/user/settings/password', user.checkSession, user.checkPassword, user.changePassword, user.update);
 app.put('/api/user/settings/email', user.checkSession, user.updateForwardEmail, user.update);
 
 app.post('/api/logout', user.logout);

--- a/server/user/userController.js
+++ b/server/user/userController.js
@@ -67,7 +67,7 @@ module.exports = {
           console.log(error);
 
           // Send error message to client
-          if (error.err) {
+          if (error) {
             if (error.err.indexOf('$username') > -1) {
               res.status(409).send({
                 error: 'Username already exists'
@@ -116,10 +116,10 @@ module.exports = {
         console.log('user does not exist');
         res.sendStatus(404);
       } else {
-        bcrypt.compare(req.body.password, user.password, function (error, response) {
+        bcrypt.compare(req.body.password, user.password, function (error, result) {
           if (error) {
             console.log(error);
-          } else if (response === false) {
+          } else if (result === false) {
             res.status(422).send('wrong password');
           } else {
             req.user = user.toJSON();
@@ -180,6 +180,28 @@ module.exports = {
         } else {
           next();
         }
+      }
+    });
+  },
+
+  checkPassword: function (req, res, next) {
+    if (!req.body.checkPassword) {
+      res.status(400).send('Missing checkPassword');
+    }
+    User.findOne({username: req.cookies.username}, function (error, user) {
+      if (error) {
+        console.log(error);
+        res.status(400).send(error);
+      } else {
+        bcrypt.compare(req.body.checkPassword, user.password, function (error, result) {
+          if (error) {
+            console.log(error);
+          } else if (result === false) {
+            res.status(422).send('wrong password');
+          } else {
+            next();
+          }
+        });
       }
     });
   },

--- a/tests/server.js
+++ b/tests/server.js
@@ -117,7 +117,7 @@ describe('User Module', function () {
   });
 
   it('should allow users to update their password', function (done) {
-    request.put({url: serverUrl + '/api/user/settings/password', jar: j, json: true, body: {password: 'secret2'}}, function (error, httpResponse, body) {
+    request.put({url: serverUrl + '/api/user/settings/password', jar: j, json: true, body: {checkPassword: 'secret', password: 'secret2'}}, function (error, httpResponse, body) {
       if (error) {
         console.log(error);
       } else {


### PR DESCRIPTION
This adds middleware to the server to check the old password before updating the user's password. The server expects the old password to be passed in the body of the request as `{checkPassword: OLDPASS, password: NEWPASS}` to the same PUT `/api/user/settings/password` as before.

This also updates the tests to send the old pass, and these changes pass all of the current tests.