### PR TITLE
Clarify that Emails can be clicked on

### DIFF
--- a/client/js/components/emails.js
+++ b/client/js/components/emails.js
@@ -11,36 +11,36 @@ var Snackbar = require('material-ui').Snackbar;
 var Actions = require('../actions/actions');
 var storeWatchMixin = require('../mixins/StoreWatchMixin');
 
-var getInitialState = function() {
+var getInitialState = function () {
   return null;
 };
 
 var EmailTable = React.createClass({
   emailData: function () {
-      var dataForEmails = {
-        vips: this.props.vips
-      };
+    var dataForEmails = {
+      vips: this.props.vips
+    };
 
-      if (!this.props.data.map) {
-        dataForEmails.emails = [];
-      } else {
-        dataForEmails.emails = this.props.data
-          .map(function (escrow, i) {
-            var email = JSON.parse(escrow.email);
-            email.emailId = i;
-            email.paid = escrow.paid ? 'Paid' : 'Unpaid';
-            email.cost = dollarString.fromCents(escrow.cost);
-            email.sentDate = moment(escrow.sentDate).format('MMM D');
-            email.sentTime = escrow.sentDate;
-            email.vips = dataForEmails.vips;
-            return email;
-          }).sort(function (a, b) {
+    if (!this.props.data.map) {
+      dataForEmails.emails = [];
+    } else {
+      dataForEmails.emails = this.props.data
+        .map(function (escrow, i) {
+          var email = JSON.parse(escrow.email);
+          email.emailId = i;
+          email.paid = escrow.paid ? 'Paid' : 'Unpaid';
+          email.cost = dollarString.fromCents(escrow.cost);
+          email.sentDate = moment(escrow.sentDate).format('MMM D');
+          email.sentTime = escrow.sentDate;
+          email.vips = dataForEmails.vips;
+          return email;
+        }).sort(function (a, b) {
           // Sort emails by newest first
           return new Date(b.sentTime) - new Date(a.sentTime);
         });
-      }
+    }
 
-      return dataForEmails;
+    return dataForEmails;
   },
 
   render: function () {
@@ -52,7 +52,7 @@ var EmailTable = React.createClass({
             <th>Subject</th>
             <th>Date</th>
             <th>Price</th>
-            <th>Paid</th>
+            <th>Status</th>
             <th></th>
           </tr>
         </thead>
@@ -80,7 +80,7 @@ var EmailRow = React.createClass({
     e.preventDefault();
     if (this.props.vips.indexOf(this.props.from) > -1){
       this.refs.duplicateEmail.show();
-      setTimeout(function() {
+      setTimeout(function () {
         this.refs.duplicateEmail.dismiss();
       }.bind(this), 1000);
     } else {
@@ -89,7 +89,7 @@ var EmailRow = React.createClass({
         remove: []
       });
       this.refs.addEmail.show();
-      setTimeout(function() {
+      setTimeout(function () {
         this.refs.addEmail.dismiss();
       }.bind(this), 1000);
     }

--- a/client/less/dashboard/emails.less
+++ b/client/less/dashboard/emails.less
@@ -17,7 +17,7 @@
     border-bottom: 10px;
   }
 
-  tr {
+  td {
     cursor: pointer;
   }
 

--- a/client/less/dashboard/emails.less
+++ b/client/less/dashboard/emails.less
@@ -6,7 +6,7 @@
   td, th {
     padding: 1em;
     margin: 1px;
-    background-color: #eee;
+    background-color: rgba(245, 245, 245, .9);
   }
 
   th {
@@ -21,7 +21,13 @@
     cursor: pointer;
   }
 
+  tbody tr:hover {
+    background-color: #000;
+    transition: all 800ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+  }
+
   .escrow-snackbar {
+    display: none;
     background-color: transparent;
   }
 }


### PR DESCRIPTION
This pull-request:

* changes the background color of the Emails rows when you hover over them
* restores the normal mouse pointer to the Emails table header row to emphasize what can be clicked (since sorting doesn't work for now)
* changes the table label from `Paid` to `Status` for the column with `Paid` vs `Unpaid`, because it looked off to see Paid above Paid