### PR TITLE
(fix) change Dashboard auto-refresh rate to 30 seconds

### DIFF
--- a/client/js/components/dashboard.js
+++ b/client/js/components/dashboard.js
@@ -8,6 +8,7 @@ var RouteHandler = Router.RouteHandler;
 
 var Actions = require('../actions/actions');
 var Store = require('../stores/store');
+var refreshRate = 30000;
 
 var Authentication = {
   statics: {
@@ -26,9 +27,9 @@ var Dashboard = React.createClass({
   getInitialState: function () {
     if (Store.isUserLoggedIn()) {
       Actions.getDashboardInfo();
-      setTimeout(function() {
+      setTimeout(function () {
         this.getInitialState();
-      }.bind(this), 10000);
+      }.bind(this), refreshRate);
     }
     return Store.getUserData();
   },
@@ -79,7 +80,7 @@ var Dashboard = React.createClass({
     { route: 'logout', text: 'Log Out'}
   ],
 
-  render: function() {
+  render: function () {
     var username = cookie.parse(document.cookie).username;
     var balance = 'Balance: ' + dollarString.fromCents(this.state.userSettings.balance);
     return (


### PR DESCRIPTION
The current auto refresh rate was so high it was causing trouble for my server. 
This sets it to 30 seconds, which should still be fine.