### PR TITLE
(fix) move superagent to server dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mongoose-private": "~0.1.3",
     "react-tap-event-plugin": "^0.1.4",
     "sendgrid": "~1.6.0",
+    "superagent": "^0.21.0",
     "stripe": "~3.3.0"
   },
   "devDependencies": {
@@ -73,7 +74,6 @@
     "react-tools": "^0.12.2",
     "reactify": "^1.0.0",
     "request": "~2.53.0",
-    "superagent": "^0.21.0",
     "vinyl-source-stream": "^1.0.0"
   }
 }


### PR DESCRIPTION
Superagent was being used in server/gmail but only listed in devDependencies, causing the deployed server to crash.