### PR TITLE
(fix) use env.STRIPE_PROMISE on payments page for test vs. production environments

### DIFF
--- a/server/payment/paymentController.js
+++ b/server/payment/paymentController.js
@@ -34,7 +34,7 @@ module.exports = {
 
   paymentRequest: function (req, res) {
     var cost = Math.ceil((req.cost * 1.029) + 30);
-    res.render('payment', {name: 'Gilded Club Payment', amount: cost, paid: req.paid});
+    res.render('payment', {name: 'Gilded Club Payment', amount: cost, paid: req.paid, stripePromise: process.env.STRIPE_PROMISE});
   },
 
   verification: function (req, res, next) {

--- a/views/payment.jade
+++ b/views/payment.jade
@@ -41,6 +41,6 @@ html
             p Don't worry, we are holding your message in escrow for a week. It will be immediately forwarded to them once payment is complete.
           div(class="payment")
               form(method="post")
-                script(src="https://checkout.stripe.com/checkout.js", class="stripe-button", data-key="pk_test_8kvjMq55qMQ1JwQ73W73C8no", data-amount!= amount, data-name="Gilded Club", data-description!= '$' + (amount/100).toFixed(2), data-image="/assets/icon-128x128.png", data-bitcoin="true")
+                script(src="https://checkout.stripe.com/checkout.js", class="stripe-button", data-key="#{stripePromise}", data-amount!= amount, data-name="Gilded Club", data-description!= '$' + (amount/100).toFixed(2), data-image="/assets/icon-128x128.png", data-bitcoin="true")
     script(src="../bower_components/jquery/dist/jquery.min.js")
     script(src="../bower_components/bootstrap/dist/js/bootstrap.min.js")


### PR DESCRIPTION
Fixes the payment page to use the right Stripe environment. You need to add a new `STRIPE_DOMAIN` var to your environment variables!