### PR TITLE
(fix) hide the testimonials for now

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -133,11 +133,11 @@
       </div>
     </div>
     <div class="container bg testimonial">
-      <blockquote>
+      <blockquote style="display:none;">
         <p>"I no longer worry about spammers finding my email address. <br>Now I <em>want</em> people to email me."</p>
         <footer><cite>Eric Schmidt</cite></footer>
       </blockquote>
-      <blockquote class="blockquote-reverse">
+      <blockquote class="blockquote-reverse" style="display:none;">
         <p>"Finally, I can stop worrying about stalkers."</p>
         <footer><cite>Jacky Chan</cite></footer>
       </blockquote>


### PR DESCRIPTION
Hiding the testimonials for now based on response on Hacker News. Just using `display: none;`-- will want better long term solution.
